### PR TITLE
Add cleaner function to trim park data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import './App.css'
 import { useState, useEffect } from 'react'
 import { Routes, Route } from 'react-router-dom';
-import { filterAccessibleAmenities, filterAllParks } from './utilities'
+import { filterAccessibleAmenities, filterAllParks, trimParkData } from './utilities'
 import { fetchAmenities, fetchParks } from './api-calls'
 import Header from './components/Header/Header'
 import SinglePark from './components/SinglePark/SinglePark'
@@ -29,7 +29,8 @@ function App() {
         if (filteredAmenities) {
           const parksData = await fetchParks();
           const filteredParks = filterAllParks(filteredAmenities, parksData.data);
-          setAllParks(filteredParks);
+          const trimmedParkData = trimParkData(filteredParks)
+          setAllParks(trimmedParkData);
         }
       } catch (error) {
         console.log(`Request failed - ${error.message}`);

--- a/src/components/AllFavorites/AllFavorites.js
+++ b/src/components/AllFavorites/AllFavorites.js
@@ -17,8 +17,8 @@ const AllFavorites = ({ savedParks, selectSinglePark, setSavedParks }) => {
         id={natPark.id}
         name={natPark.fullName}
         state={natPark.states}
-        image={natPark.images[0].url}
-        altText={natPark.images[0].altText}
+        altText={natPark.images.altText}
+        image={natPark.images.url}
         selectSinglePark={selectSinglePark}
         helperDeletePark={helperDeletePark}
       />

--- a/src/components/AllParks/AllParks.js
+++ b/src/components/AllParks/AllParks.js
@@ -9,7 +9,9 @@ const AllParks = ({ allParks, selectSinglePark }) => {
         id={natPark.id}
         name={natPark.fullName}
         state={natPark.states}
-        image={natPark.images[0].url}
+        altText={natPark.images.altText}
+        image={natPark.images.url}
+
         selectSinglePark={selectSinglePark}
       />
     )

--- a/src/components/ParkCard/ParkCard.js
+++ b/src/components/ParkCard/ParkCard.js
@@ -6,7 +6,7 @@ return (
  <Link to={`/${props.name}`}>
     <div className='park-card' key={props.id} onClick={() => props.selectSinglePark(props.name)}>
       <div className='image-container'>
-        <img src={props.image}/>
+        <img src={props.image} alt={props.altText}/>
       </div>
       <div className='info-container'>
         <h2>{props.name}</h2>

--- a/src/components/SinglePark/SinglePark.css
+++ b/src/components/SinglePark/SinglePark.css
@@ -4,7 +4,7 @@
     width: 100vw;
 }
 
-.single-park-info-container img {
+#park-image {
     display: flex;
     width: 20em;
 }

--- a/src/components/SinglePark/SinglePark.js
+++ b/src/components/SinglePark/SinglePark.js
@@ -61,11 +61,16 @@ const SinglePark = ({
     setSavedParks([...savedParks, park])
   }
 
-  return (
+  return selectedSinglePark && (
     <div className='single-park-container'>
       <div className='single-park-info-container'>
         <div className='styling-container'>
           <h2>{selectedSinglePark.fullName}</h2>
+          <img
+            src={selectedSinglePark.images.url}
+            alt={selectedSinglePark.images.altText}
+            id='park-image'
+          />
           <div className='styling-container-two'>
             <h3>{selectedSinglePark.states}</h3>
             <h3>{selectedSinglePark.designation}</h3>

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -52,15 +52,17 @@ const filterAllParks = (accessibleParks, allParks) => {
     const accessParks = allParks.filter((park) => {
         return accessibleParksList.includes(park.fullName)
     })
-    // let trimmedParkData = accessParks.reduce((object, park) => {
-
-
-      // return object
-    // })
 
     return accessParks
 }
 
+const trimParkData = (allParks) => {
+  const reducedData = allParks.map(park => {
+      const { id, fullName, url, states, description, images, } = park;
+      return { id, fullName, url, states, description, images: images[0] };
+  });
+  return reducedData;
+}
 
 
-export { filterAccessibleAmenities, filterAllParks }
+export { filterAccessibleAmenities, filterAllParks, trimParkData }


### PR DESCRIPTION
What I did: 

- Add trimParkData fn to utils.js to reduce park data to properties including: id, fullName, url, states, description, and images
- Refactor SinglePark component to render correct image url

Testing Notes/Extras: 

Did this break anything?
- [ ]  No
- [X]  Yes 

Type of change
- [ ]  New feature (non-breaking change which adds functionality)
- [X]  Bug fix (non-breaking change which fixes an issue)
- [X]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Added testing for: 
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:
- [ ]  If this code needs to be tested, all tests are passing
- [X]  The code runs locally
- [X]  The code is DRY. If it's not, I tried my best
- [X]  I reviewed my code before pushing

What's next?
Add testing
Add proptypes